### PR TITLE
Wording: NL-RSE stands for Research Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-## The Netherlands Research Software Engineer community
+## The Netherlands Research Software Engineers community
 
 [Join our community](https://lists.nl-rse.org/mailman/listinfo/everyone) of 200+ members from 30+ institutes and stay informed about activities by signing up to our mailing list!
 

--- a/_pages/communication.md
+++ b/_pages/communication.md
@@ -4,7 +4,7 @@ title: Communicate
 ---
 
 Once you have [joined the mailinglist](https://lists.nl-rse.org/mailman/listinfo/everyone), there are several options for getting involved with the dynamic and friendly
-Research Software Engineering community:
+Research Software Engineers community:
 
 ### Join the discussion
 
@@ -22,7 +22,3 @@ Do you have an upcoming event, job opening or other news to share with the commu
 ### Contact the organisers
 
 Would you like to share somethind during our next [meetup](/pages/meetups.html)? Email info@nl-rse.org to get in contact with the NL-RSE committee and conference organisers
-
-
-
-

--- a/_pages/meetups.md
+++ b/_pages/meetups.md
@@ -12,7 +12,7 @@ collaboration and communication between Research Software Engineers in the Nethe
 During the Covid19 pandemic, meetings will be organised online.
 
 Topics of the lectures and hands-on workshops range from new developments in programming languages
-and frameworks to practical tips for research software engineering, and more.
+and frameworks to practical tips for research software engineers, and more.
 Speakers are usually but not exclusively members of the NL-RSE community (i.e. Dutch Research Software Engineers). The agenda of the meeting leaves plenty of time for participants to interact with each other.
 
 NL-RSE meetups are the continuation of DTL SURF Programmers meetings. You can learn more about those and see past agendas on [DTL website](https://www.dtls.nl/community/meetings/programmers-meetings/).


### PR DESCRIPTION
The E in NL-RSE stands for Engineers, and not Engineering, reflecting the focus on the people. This PR changes the wording in a couple of places to make sure we are consistent.